### PR TITLE
Bump gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,8 @@ AllCops:
     - Gemfile
     - Rakefile
   Exclude:
-   - cookbooks/**
-   - tmp/**
+   - cookbooks/**/*
+   - tmp/**/*
 
 SingleSpaceBeforeFirstArg:
   Enabled: false # Useful for more readable alignment of method call args

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'soloist',    require: false
-gem 'foodcritic', require: false
+gem 'foodcritic', require: false, git: 'https://github.com/acrmp/foodcritic'
 gem 'rspec',      require: false
 gem 'rubocop',    require: false
 gem 'chefspec',   require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,23 @@
+GIT
+  remote: https://github.com/acrmp/foodcritic
+  revision: ca7e8ac1c4828c9633ccffdacfa1507ea05b706b
+  specs:
+    foodcritic (3.0.3)
+      erubis
+      gherkin (~> 2.11)
+      nokogiri (~> 1.5)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
-    ast (1.1.0)
+    ast (2.0.0)
     awesome_print (1.2.0)
-    chef (11.12.2)
+    chef (11.12.4)
       chef-zero (~> 2.0, >= 2.0.2)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -18,33 +31,26 @@ GEM
       mixlib-shellout (~> 1.4)
       net-ssh (~> 2.6)
       net-ssh-multi (~> 1.1)
-      ohai (~> 7.0)
+      ohai (~> 7.0.4)
       pry (~> 0.9)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
-    chef-zero (2.0.2)
+    chef-zero (2.1.5)
       hashie (~> 2.0)
       json
       mixlib-log (~> 1.3)
       rack
-    chefspec (3.4.0)
-      chef (~> 11.0)
+    chefspec (4.0.0)
+      chef (~> 11.12)
       fauxhai (~> 2.0)
-      rspec (~> 2.14)
+      rspec (~> 3.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    fauxhai (2.1.0)
+    fauxhai (2.1.2)
       net-ssh
       ohai
-    foodcritic (3.0.3)
-      erubis
-      gherkin (~> 2.11.7)
-      nokogiri (~> 1.5.4)
-      rake
-      treetop (~> 1.4.10)
-      yajl-ruby (~> 1.1.0)
-    gherkin (2.11.8)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
     hashie (2.1.1)
     highline (1.6.21)
@@ -59,21 +65,23 @@ GEM
       librarian (~> 0.1.0)
     method_source (0.8.2)
     mime-types (1.25.1)
+    mini_portile (0.6.0)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.4.0)
+    mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (1.4.0)
-    multi_json (1.9.2)
-    net-ssh (2.8.0)
+    multi_json (1.10.1)
+    net-ssh (2.9.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.2.0)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    nokogiri (1.5.11)
-    ohai (7.0.2)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
+    ohai (7.0.4)
       ipaddress
       mime-types (~> 1.16)
       mixlib-cli
@@ -82,10 +90,10 @@ GEM
       mixlib-shellout (~> 1.2)
       systemu (~> 2.5.2)
       yajl-ruby
-    parser (2.1.7)
-      ast (~> 1.1)
+    parser (2.1.9)
+      ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
-    polyglot (0.3.4)
+    polyglot (0.3.5)
     powerpack (0.0.9)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -93,24 +101,29 @@ GEM
       slop (~> 3.4)
     rack (1.5.2)
     rainbow (2.0.0)
-    rake (10.2.2)
+    rake (10.3.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
-    rubocop (0.20.1)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.0)
+    rubocop (0.23.0)
       json (>= 1.7.7, < 2)
-      parser (~> 2.1.7)
+      parser (~> 2.1.9)
       powerpack (~> 0.0.6)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.4.2)
+    ruby-progressbar (1.5.1)
+    rufus-lru (1.0.5)
     slop (3.5.0)
     soloist (1.0.3)
       awesome_print
@@ -121,17 +134,16 @@ GEM
       thor
     systemu (2.5.2)
     thor (0.19.1)
-    treetop (1.4.15)
-      polyglot
-      polyglot (>= 0.3.1)
-    yajl-ruby (1.1.0)
+    treetop (1.5.3)
+      polyglot (~> 0.3)
+    yajl-ruby (1.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   chefspec
-  foodcritic
+  foodcritic!
   rspec
   rubocop
   soloist

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require 'rubocop/rake_task'
 desc 'Run foodcritic && rubocop && spec:unit'
 task default: %w(foodcritic rubocop spec:unit)
 
-
 desc 'Run default && spec:integration'
 task ci: %w(default spec:integration)
 
@@ -14,7 +13,7 @@ task :foodcritic do
   sh 'foodcritic . -f any'
 end
 
-Rubocop::RakeTask.new
+RuboCop::RakeTask.new
 
 namespace :spec do
   desc 'Run unit specs (ChefSpec)'

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'sprout-exemplar' do
   before :all do
     expect(File).not_to be_exists("#{ENV['HOME']}/exemplar")
-    expect(system('soloist')).to be_true
+    expect(system('soloist')).to eq(true)
   end
 
   it 'creates a file in the home directory' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'rspec'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -4,9 +4,8 @@ require 'chefspec/librarian'
 
 RSpec.configure do |config|
   config.platform = 'mac_os_x'
-  config.version = '10.8.2' # FIXME: system ruby and fauxhai don't play nice
-                            # since there is no 10.9.2.json file yet. We
-                            # should submit a PR to fauxhai to fix this
+  config.version = '10.9.2' # FIXME: change to 10.9.3.json when available ...
+  # see https://github.com/customink/fauxhai/tree/master/lib/fauxhai/platforms/mac_os_x
   config.before { stub_const('ENV', 'SUDO_USER' => 'fauxhai') }
   config.after(:suite)  { FileUtils.rm_r('.librarian') }
 end


### PR DESCRIPTION
- pull foodcritic from github to avoid nokogiri install issues
- update exclude paterns in .rubocop.yml
- fix deprecations in spec_helper
- Rubocop => RuboCop in latest version
