### PR TITLE
Reorganize .gitignore and add .bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-Cheffile.lock
-tmp/
-cookbooks/
+.bundle/
 .idea/
 .librarian/
+tmp/
+cookbooks/
+Cheffile.lock


### PR DESCRIPTION
- allows users to run `bundle install --path tmp/vendor` and not install into common gem location
