### PR TITLE
Bump mixlib-shellout to non-yanked version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     multi_json (1.10.1)
     net-ssh (2.9.1)
     net-ssh-gateway (1.2.0)
@@ -152,3 +152,6 @@ DEPENDENCIES
   rspec
   rubocop
   soloist
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
- This was preventing bundling and running builds
- Also added 'BUNDLED WITH' to Gemfile.lock